### PR TITLE
Added support for global Config object in runtime

### DIFF
--- a/examples/creating_configs/main.ts
+++ b/examples/creating_configs/main.ts
@@ -1,0 +1,11 @@
+import { saveConfig } from '../../dist'
+
+const config = saveConfig('config')
+
+config.getConfig().set('numbers', [ 0, 1, 3, 4, 5, 6, 7, 8, 9, 10 ])
+config.getConfig().getIntegerList('numbers')?.forEach((number) => {
+    console.log(number)
+
+})
+
+config.saveConfig()

--- a/examples/creating_configs/tsconfig.json
+++ b/examples/creating_configs/tsconfig.json
@@ -1,0 +1,28 @@
+{
+	"compileOnSave": false,
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "./dist",
+		"sourceMap": false,
+		"declaration": false,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"emitDecoratorMetadata": true,
+		"resolveJsonModule": true,
+		"experimentalDecorators": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"importHelpers": true,
+		"target": "es3",
+		"typeRoots": [
+			"../../node_modules/@types"
+		],
+		"lib": [
+			"es2018",
+			"dom"
+		]
+	},
+	"files": [
+		"main.ts"
+	]
+}

--- a/examples/creating_configs/webpack.config.js
+++ b/examples/creating_configs/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+module.exports = {
+    entry: './main.ts',
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+            },
+        ],
+    },
+    resolve: {
+        extensions: ['.tsx', '.ts', '.js'],
+    },
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+    },
+};

--- a/examples/helloworld/main.ts
+++ b/examples/helloworld/main.ts
@@ -1,12 +1,25 @@
-import { saveConfig, Material, ItemStack } from '../../dist'
+import { PlayerChatEvent, ServerCommands, ServerEvents } from "../../dist";
 
-const config = saveConfig()
+console.log('Plugin started!');
 
-const item = ItemStack.create(Material.withName('dirt')!, 1)
+// Say hello to everyone on the server, every 5 seconds
+let i = 0;
+setInterval(() => {
+    i++;
+    Java.resolve('org.bukkit.Bukkit').broadcastMessage('Hello #' + i);
+}, 5000);
 
-config.getConfig().set('savedItem', item)
-config.getConfig().set('savedItemName', item.getMaterial().getName())
+ServerEvents.register(PlayerChatEvent, event => {
 
-console.log(`Saved ${config.getConfig().getItemStack('savedItem')?.getMaterial().getName()}`)
+    console.log('Chat event!');
+    event.getPlayer().sendTitle('NICE CHAT', 'yep', 20, 20, 20);
 
-config.saveConfig()
+});
+
+ServerCommands.register('/hello {name}...', (player, call) => {
+
+    const name = call.getPlaceholder('name')!;
+
+    player.sendTitle('You said:', name, 20, 20, 20);
+
+});

--- a/examples/helloworld/main.ts
+++ b/examples/helloworld/main.ts
@@ -1,25 +1,12 @@
-import { PlayerChatEvent, ServerCommands, ServerEvents } from "../../dist";
+import { saveConfig, Material, ItemStack } from '../../dist'
 
-console.log('Plugin started!');
+const config = saveConfig()
 
-// Say hello to everyone on the server, every 5 seconds
-let i = 0;
-setInterval(() => {
-    i++;
-    Java.resolve('org.bukkit.Bukkit').broadcastMessage('Hello #' + i);
-}, 5000);
+const item = ItemStack.create(Material.withName('dirt')!, 1)
 
-ServerEvents.register(PlayerChatEvent, event => {
+config.getConfig().set('savedItem', item)
+config.getConfig().set('savedItemName', item.getMaterial().getName())
 
-    console.log('Chat event!');
-    event.getPlayer().sendTitle('NICE CHAT', 'yep', 20, 20, 20);
+console.log(`Saved ${config.getConfig().getItemStack('savedItem')?.getMaterial().getName()}`)
 
-});
-
-ServerCommands.register('/hello {name}...', (player, call) => {
-
-    const name = call.getPlaceholder('name')!;
-
-    player.sendTitle('You said:', name, 20, 20, 20);
-
-});
+config.saveConfig()

--- a/src/config/saveConfig.ts
+++ b/src/config/saveConfig.ts
@@ -1,0 +1,3 @@
+import { FileManager } from "./types/FileManager"
+
+export const saveConfig = (file?: string) => { return FileManager.fromJava(Config.save(file || 'config')) }

--- a/src/config/saveConfig.ts
+++ b/src/config/saveConfig.ts
@@ -1,3 +1,5 @@
-import { FileManager } from "./types/FileManager"
+import { FileManager } from './types/FileManager';
 
-export const saveConfig = (file?: string) => { return FileManager.fromJava(Config.save(file || 'config')) }
+export const saveConfig = (file?: string) => {
+	return FileManager.fromJava(Config.save(file || 'config'));
+};

--- a/src/config/types/FileConfiguration.ts
+++ b/src/config/types/FileConfiguration.ts
@@ -1,8 +1,7 @@
-import { ItemStack } from "../..";
-import { ToJava } from "../../runtime/ToJava";
+import { ItemStack } from '../..';
+import { ToJava } from '../../runtime/ToJava';
 
 export class FileConfiguration implements ToJava {
-    
 	public static fromJava(_fileConfiguration: Java.Value): FileConfiguration {
 		return new FileConfiguration(_fileConfiguration);
 	}
@@ -13,29 +12,28 @@ export class FileConfiguration implements ToJava {
 		return this._fileConfiguration;
 	}
 
-    public getString(path: string): string | null {
-        return this.toJava().getString(path)
+	public getString(path: string): string | null {
+		return this.toJava().getString(path);
+	}
 
-    }
+	public getBoolean(path: string): boolean | null {
+		return this.toJava().getBoolean(path);
+	}
 
-    public getBoolean(path: string): boolean | null {
-        return this.toJava().getBoolean(path)
+	public getInt(path: string): number | null {
+		return this.toJava().getInt(path);
+	}
 
-    }
+	public getItemStack(path: string): ItemStack | null {
+		return ItemStack.fromJava(this.toJava().getItemStack(path));
+	}
 
-    public getInt(path: string): number | null {
-        return this.toJava().getInt(path)
-
-    }
-
-    public getItemStack(path: string): ItemStack | null{
-        return ItemStack.fromJava(this.toJava().getItemStack(path))
-
-    }
-
-    public set(path: string, object: any) {
-        this.toJava().set(path, object instanceof Object && object.toJava != null ? object.toJava() : object)
-
-    }
-
+	public set(path: string, object: any) {
+		this.toJava().set(
+			path,
+			object instanceof Object && object.toJava != null
+				? object.toJava()
+				: object
+		);
+	}
 }

--- a/src/config/types/FileConfiguration.ts
+++ b/src/config/types/FileConfiguration.ts
@@ -28,6 +28,10 @@ export class FileConfiguration implements ToJava {
 		return ItemStack.fromJava(this.toJava().getItemStack(path));
 	}
 
+	public getStringList(path: string): string[] | null {
+		return this.toJava().getStringList(path);
+	}
+
 	public set(path: string, object: any) {
 		this.toJava().set(
 			path,

--- a/src/config/types/FileConfiguration.ts
+++ b/src/config/types/FileConfiguration.ts
@@ -1,0 +1,41 @@
+import { ItemStack } from "../..";
+import { ToJava } from "../../runtime/ToJava";
+
+export class FileConfiguration implements ToJava {
+    
+	public static fromJava(_fileConfiguration: Java.Value): FileConfiguration {
+		return new FileConfiguration(_fileConfiguration);
+	}
+
+	private constructor(private _fileConfiguration: Java.Value) {}
+
+	public toJava(): Java.Value {
+		return this._fileConfiguration;
+	}
+
+    public getString(path: string): string | null {
+        return this.toJava().getString(path)
+
+    }
+
+    public getBoolean(path: string): boolean | null {
+        return this.toJava().getBoolean(path)
+
+    }
+
+    public getInt(path: string): number | null {
+        return this.toJava().getInt(path)
+
+    }
+
+    public getItemStack(path: string): ItemStack | null{
+        return ItemStack.fromJava(this.toJava().getItemStack(path))
+
+    }
+
+    public set(path: string, object: any) {
+        this.toJava().set(path, object instanceof Object && object.toJava != null ? object.toJava() : object)
+
+    }
+
+}

--- a/src/config/types/FileManager.ts
+++ b/src/config/types/FileManager.ts
@@ -1,9 +1,8 @@
-import { ToJava } from "../../runtime/ToJava";
-import { FileConfiguration } from './FileConfiguration'
+import { ToJava } from '../../runtime/ToJava';
+import { FileConfiguration } from './FileConfiguration';
 
 export class FileManager implements ToJava {
-
-    public static fromJava(_file_manager: Java.Value) {
+	public static fromJava(_file_manager: Java.Value) {
 		return new FileManager(_file_manager);
 	}
 
@@ -13,19 +12,15 @@ export class FileManager implements ToJava {
 		return this._file_manager;
 	}
 
-    public getConfig() {
-        return FileConfiguration.fromJava(this.toJava().getConfig())
+	public getConfig() {
+		return FileConfiguration.fromJava(this.toJava().getConfig());
+	}
 
-    }
+	public saveConfig() {
+		this.toJava().saveConfig();
+	}
 
-    public saveConfig() {
-        this.toJava().saveConfig()
-    
-    }
-    
-    public reloadConfig() {
-        this.toJava().reloadConfig()
-    
-    }
-
+	public reloadConfig() {
+		this.toJava().reloadConfig();
+	}
 }

--- a/src/config/types/FileManager.ts
+++ b/src/config/types/FileManager.ts
@@ -1,0 +1,31 @@
+import { ToJava } from "../../runtime/ToJava";
+import { FileConfiguration } from './FileConfiguration'
+
+export class FileManager implements ToJava {
+
+    public static fromJava(_file_manager: Java.Value) {
+		return new FileManager(_file_manager);
+	}
+
+	private constructor(private _file_manager: Java.Value) {}
+
+	public toJava(): Java.Value {
+		return this._file_manager;
+	}
+
+    public getConfig() {
+        return FileConfiguration.fromJava(this.toJava().getConfig())
+
+    }
+
+    public saveConfig() {
+        this.toJava().saveConfig()
+    
+    }
+    
+    public reloadConfig() {
+        this.toJava().reloadConfig()
+    
+    }
+
+}

--- a/src/config/types/index.ts
+++ b/src/config/types/index.ts
@@ -1,2 +1,2 @@
-export * from './FileManager'
-export * from './FileConfiguration'
+export * from './FileManager';
+export * from './FileConfiguration';

--- a/src/config/types/index.ts
+++ b/src/config/types/index.ts
@@ -1,0 +1,2 @@
+export * from './FileManager'
+export * from './FileConfiguration'

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,3 +1,5 @@
+import { FileConfiguration } from "./config/types";
+
 export {};
 
 // The globals found in this file are documented here, but implemented in Java in the `bukkit-runtime` project.
@@ -67,4 +69,19 @@ declare global {
 		 */
 		function unregister(handle: number): void;
 	}
+
+	/**
+	 * Config namespace contains functions that enable the caller to save config (yml) files
+	 */
+	namespace Config {
+
+		/**
+		 * Creates new config file in plugins directory
+		 * @param file how the config file shoulbed be names
+		 */
+
+		function save(file: string): FileConfiguration
+
+	}
+
 }

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { FileConfiguration } from "./config/types";
+import { FileConfiguration } from './config/types';
 
 export {};
 
@@ -74,14 +74,11 @@ declare global {
 	 * Config namespace contains functions that enable the caller to save config (yml) files
 	 */
 	namespace Config {
-
 		/**
 		 * Creates new config file in plugins directory
 		 * @param file how the config file shoulbed be names
 		 */
 
-		function save(file: string): FileConfiguration
-
+		function save(file: string): FileConfiguration;
 	}
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,9 @@ export * from './sound/Note';
 export * from './sound/Pitch';
 export * from './sound/Tone';
 
+export * from './config/types'
+export * from './config/saveConfig'
+
 // ./types/...
 
 export * from './util/Location';

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,8 @@ export * from './sound/Note';
 export * from './sound/Pitch';
 export * from './sound/Tone';
 
-export * from './config/types'
-export * from './config/saveConfig'
+export * from './config/types';
+export * from './config/saveConfig';
 
 // ./types/...
 


### PR DESCRIPTION
# Added support for [Config ](https://github.com/customrealms/bukkit-runtime/pull/9) object
To create config use
```ts
import { saveConfig } from '@customrealms/core'

const config= saveConfig() // Creates config.yml
const dataConfig= saveConfig('data') // Creates data.yml

// Put data
config.getConfig().set('message', 'this is a message')

// Get data
console.log(defualtConfig.getConfig().getString('message'))

// saves config
config.saveConfig()

// Reload config
config.reloadConfig()

```
# Note
There are some function missing, but will be added