### PR TITLE
feat: polyfill for Array.prototype.includes and String.prototype.includes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './globals';
 
 // Polyfills for ES6 features that are not available in Nashorn
 import './polyfill/array';
+import './polyfill/string';
 
 // Convenience exports of some common classes
 export const Bukkit = org.bukkit.Bukkit;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ export * from './java';
 export * from './bukkit';
 export * from './globals';
 
+// Polyfills for ES6 features that are not available in Nashorn
+import './polyfill/array';
+
 // Convenience exports of some common classes
 export const Bukkit = org.bukkit.Bukkit;
 

--- a/src/polyfill/array.ts
+++ b/src/polyfill/array.ts
@@ -1,5 +1,8 @@
 if (!Array.prototype.includes) {
-    Array.prototype.includes = function(searchElement: any, fromIndex?: number): boolean {
-        return this.indexOf(searchElement, fromIndex) !== -1;
-    };
+	Array.prototype.includes = function (
+		searchElement: any,
+		fromIndex?: number
+	): boolean {
+		return this.indexOf(searchElement, fromIndex) !== -1;
+	};
 }

--- a/src/polyfill/array.ts
+++ b/src/polyfill/array.ts
@@ -1,0 +1,5 @@
+if (!Array.prototype.includes) {
+    Array.prototype.includes = function(searchElement: any, fromIndex?: number): boolean {
+        return this.indexOf(searchElement, fromIndex) !== -1;
+    };
+}

--- a/src/polyfill/string.ts
+++ b/src/polyfill/string.ts
@@ -1,5 +1,8 @@
 if (!String.prototype.includes) {
-    String.prototype.includes = function(searchString: string, position?: number): boolean {
-        return this.indexOf(searchString, position) !== -1;
-    };
+	String.prototype.includes = function (
+		searchString: string,
+		position?: number
+	): boolean {
+		return this.indexOf(searchString, position) !== -1;
+	};
 }

--- a/src/polyfill/string.ts
+++ b/src/polyfill/string.ts
@@ -1,0 +1,5 @@
+if (!String.prototype.includes) {
+    String.prototype.includes = function(searchString: string, position?: number): boolean {
+        return this.indexOf(searchString, position) !== -1;
+    };
+}


### PR DESCRIPTION
Added polyfills for:

- `Array.prototype.includes`
- `String.prototype.includes`

More polyfills will be needed in the future, as we encounter them. We may consider a project like [core-js](https://github.com/zloirock/core-js) if this becomes too difficult to maintain.