### PR TITLE
fix: update discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ This library serves several important purposes:
 
 ## Contributing
 
-We need your help to implement new features, fix bugs, and optimize the entire system. If you want to help, please join our [Discord](https://discord.com/invite/bbS2ACdTCM) and/or check out the [Issues tab](https://github.com/customrealms/core/issues).
+We need your help to implement new features, fix bugs, and optimize the entire system. If you want to help, please join our [Discord](https://discord.gg/bsTearKQsm) and/or check out the [Issues tab](https://github.com/customrealms/core/issues).


### PR DESCRIPTION
Updated the Discord invite link, since the old link expired.

This link should never expire: https://discord.gg/bsTearKQsm

Fixes #49 